### PR TITLE
 Fix dispatcher url-pattern and spring default login page 

### DIFF
--- a/mvc/src/main/java/com/insclix/mvc/server/config/WebSecurityConfig.java
+++ b/mvc/src/main/java/com/insclix/mvc/server/config/WebSecurityConfig.java
@@ -24,6 +24,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
             .and()
                 .formLogin()
                     .defaultSuccessUrl("/", true)
+                    //.loginPage("/login")
                     .loginProcessingUrl("/login")
             .and()
                 .logout()

--- a/mvc/src/main/java/com/insclix/mvc/server/config/WebSecurityConfig.java
+++ b/mvc/src/main/java/com/insclix/mvc/server/config/WebSecurityConfig.java
@@ -24,7 +24,6 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
             .and()
                 .formLogin()
                     .defaultSuccessUrl("/", true)
-                    .loginPage("/login")
                     .loginProcessingUrl("/login")
             .and()
                 .logout()

--- a/mvc/src/main/webapp/WEB-INF/web.xml
+++ b/mvc/src/main/webapp/WEB-INF/web.xml
@@ -81,7 +81,7 @@
   </servlet>
   <servlet-mapping>
     <servlet-name>dispatcher</servlet-name>
-    <url-pattern>/</url-pattern>
+    <url-pattern>/*</url-pattern>
   </servlet-mapping>
 
   <filter>
@@ -91,7 +91,7 @@
   <filter-mapping>
     <filter-name>requestContextFilter</filter-name>
     <servlet-name>dispatcher</servlet-name>
-    <url-pattern>*</url-pattern>
+    <url-pattern>/*</url-pattern>
   </filter-mapping>
 
   <filter>


### PR DESCRIPTION
I basically just fix the dispatcher url patterns in web.xml and then removed the loginPage() method in WebSecurityConfig, this enables the default spring security login page, otherwise it will be looking for a resource called "/login" which does not exist (as in there is no spring configured controller for example for such a url)